### PR TITLE
Ensure silence is active during healthcheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/iamkirkbater/osd-cluster-ready-job
+module github.com/openshift/osd-cluster-ready-job
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ const (
 	cleanCheckIntervalDefault = 30
 
 	// The number of seconds to sleep after a failed health check.
-	failedCheckIntervalKey = "FAILED_CHECK_INTERVAL_SECONDS"
+	failedCheckIntervalKey     = "FAILED_CHECK_INTERVAL_SECONDS"
 	failedCheckIntervalDefault = 60
 )
 
@@ -66,12 +66,12 @@ func main() {
 		if clusterTooOld(clusterBirth, maxClusterAge) {
 			log.Printf("Cluster is older than %d minutes. Exiting Cleanly.", maxClusterAge)
 			// Make sure no silence is active
-			silenceID, err := silence.FindExisting()
+			amSilence, err := silence.FindExisting()
 			if err != nil {
 				log.Fatal(err)
 			}
-			if silenceID != "" {
-				err = silence.Remove(silenceID)
+			if amSilence.ID != "" {
+				err = silence.Remove(amSilence.ID)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -84,14 +84,14 @@ func main() {
 			log.Fatal(err)
 		}
 
-		silenceID, err := silence.FindExisting()
+		amSilence, err := silence.FindExisting()
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		if healthy {
-			if silenceID != "" {
-				err = silence.Remove(silenceID)
+			if amSilence.ID != "" {
+				err = silence.Remove(amSilence.ID)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -103,8 +103,8 @@ func main() {
 
 		// If we got here, our cluster is unhealthy. Make sure our silence is active.
 		// We do this every time because the silence is set to expire automatically in an hour.
-		if silenceID == "" {
-			silenceID, err = silence.Create()
+		if amSilence.ID == "" {
+			amSilence.ID, err = silence.Create()
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,10 @@ const (
 )
 
 func main() {
+	// New Alert Manager Silence Request
+	silenceReq := silence.NewSilenceRequest()
+
+	log.Printf("Please tell me you can see meee")
 	clusterBirth, err := getClusterCreationTime()
 	if err != nil {
 		log.Fatal(err)
@@ -63,15 +67,42 @@ func main() {
 	}
 
 	for {
+		log.Printf("helllooooooooo")
+		_, err := silenceReq.FindExisting()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println("Printing silenceReq struct")
+		fmt.Printf("%#v\n", silenceReq)
+
+		if silenceReq.ID != "" {
+			fmt.Println("Silence ID is blank")
+			if ok, _ := silenceReq.WillExpireBy(15 * time.Minute); ok {
+				fmt.Println("Silence expires within 15 miuntes ")
+				log.Printf("Silence will expire within 15 minutes")
+				log.Printf("Creating new silence")
+			} else {
+				fmt.Println("Silence expires after 15 minutes")
+				log.Printf("Creating silence to last a health check")
+				silenceReq.Build(10 * time.Minute).Create()
+			}
+		} else {
+			fmt.Println("Creating 12 minute silence")
+			silenceReq.Build(12 * time.Minute).Create()
+		}
+
+		fmt.Println("Passed silence being blank")
+
 		if clusterTooOld(clusterBirth, maxClusterAge) {
 			log.Printf("Cluster is older than %d minutes. Exiting Cleanly.", maxClusterAge)
 			// Make sure no silence is active
-			amSilence, err := silence.FindExisting()
+			_, err := silenceReq.FindExisting()
 			if err != nil {
 				log.Fatal(err)
 			}
-			if amSilence.ID != "" {
-				err = silence.Remove(amSilence.ID)
+			if silenceReq.ID != "" {
+				err = silenceReq.Remove()
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -84,14 +115,14 @@ func main() {
 			log.Fatal(err)
 		}
 
-		amSilence, err := silence.FindExisting()
+		amSilence, err := silenceReq.FindExisting()
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		if healthy {
 			if amSilence.ID != "" {
-				err = silence.Remove(amSilence.ID)
+				err = silenceReq.Remove()
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -103,11 +134,15 @@ func main() {
 
 		// If we got here, our cluster is unhealthy. Make sure our silence is active.
 		// We do this every time because the silence is set to expire automatically in an hour.
-		if amSilence.ID == "" {
-			amSilence.ID, err = silence.Create()
+		if silenceReq.ID == "" {
+			_, err = silenceReq.Build(1 * time.Hour).Create()
 			if err != nil {
 				log.Fatal(err)
 			}
+		} else if ok, _ := silenceReq.WillExpireBy(15 * time.Minute); ok {
+			log.Printf("End of health check silence will expire in 15 minutes")
+			log.Printf("Adding 5 minutes")
+			silenceReq.Build(15 * time.Minute).Create()
 		}
 
 		log.Printf("Health checks failed. Sleeping %d seconds before rechecking...\n", failedCheckInterval)

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -37,10 +37,14 @@ type silenceResponse struct {
 	ID string `json:"silenceID"`
 }
 
+func NewSilenceRequest() *SilenceRequest {
+	return &SilenceRequest{}
+}
+
 // FindExisting looks for an existing, active silence that was created by us. If found,
 // its ID is returned; otherwise the empty string is returned. The latter is not an
 // error condition.
-func FindExisting() (*SilenceRequest, error) {
+func (sr *SilenceRequest) FindExisting() (*SilenceRequest, error) {
 	for i := 1; i <= 300; i++ { // try once a second or so for 5-ish minutes
 		cmdstr := "oc exec -n openshift-monitoring alertmanager-main-0 -c alertmanager -- curl --silent localhost:9093/api/v2/silences -X GET"
 		silenceGetCmd := exec.Command("bash", "-c", cmdstr)
@@ -55,11 +59,11 @@ func FindExisting() (*SilenceRequest, error) {
 		err = json.Unmarshal(resp, &silences)
 		if err != nil {
 			log.Printf("There was an error unmarshalling get silence response")
-			return nil, err
+			return sr, err
 		}
 		if len(silences) == 0 {
 			log.Printf("No Silences Present")
-			return nil, nil
+			return sr, nil
 		}
 
 		for _, silence := range silences {
@@ -71,39 +75,48 @@ func FindExisting() (*SilenceRequest, error) {
 				continue
 			}
 			log.Printf("Found silence created by job: %s", silence.ID)
-			return silence, nil
+			return sr, nil
 		}
 
 		log.Printf("No silences created by job found.")
-		return nil, nil
+		return sr, nil
 	}
 
-	return nil, fmt.Errorf("unable to get a list of existing silences")
+	return sr, fmt.Errorf("unable to get a list of existing silences")
 }
 
-// Create adds a new silence that expires in one hour.
-func Create() (string, error) {
+func (sr *SilenceRequest) Build(expiryPeriod time.Duration) *SilenceRequest {
 	// Create the Silence
 	now := time.Now().UTC()
-	end := now.Add(1 * time.Hour)
+	end := now.Add(expiryPeriod)
 
 	allMatcher := matcher{}
 	allMatcher.Name = "severity"
-	allMatcher.Value = "info|warning|critical"
+	// Match all alerts
+	allMatcher.Value = ".*"
 	allMatcher.IsRegex = true
 
-	silenceBody := SilenceRequest{}
-	silenceBody.Matchers = []matcher{allMatcher}
-	silenceBody.StartsAt = now.Format(time.RFC3339)
-	silenceBody.EndsAt = end.Format(time.RFC3339)
-	silenceBody.CreatedBy = createdBy
-	silenceBody.Comment = "Created By the Cluster Readiness Job to silence any alerts during normal provisioning"
+	sr.Matchers = []matcher{allMatcher}
+	sr.StartsAt = now.Format(time.RFC3339)
+	sr.EndsAt = end.Format(time.RFC3339)
+	sr.CreatedBy = createdBy
+	sr.Comment = "Created By the Cluster Readiness Job to silence any alerts during normal provisioning"
 
-	silenceJSON, err := json.Marshal(silenceBody)
+	return sr
+}
+
+// Create adds a new silence that expires in one hour.
+func (sr *SilenceRequest) Create() (*SilenceRequest, error) {
+
+	silenceJSON, err := json.Marshal(sr)
 	if err != nil {
-		return "", fmt.Errorf("There was an error marshalling JSON: %v", silenceJSON)
+		return sr, fmt.Errorf("There was an error marshalling JSON: %v", silenceJSON)
 	}
 
+	return sr, nil
+}
+
+func (sr *SilenceRequest) Send(silenceJSON []byte) (*silenceResponse, error) {
 	for {
 		// Attempt to run once every 30 seconds until this succeeds
 		// to account for if the alertmanager is not ready before
@@ -119,19 +132,19 @@ func Create() (string, error) {
 		var silenceResp silenceResponse
 		e := json.Unmarshal(resp, &silenceResp)
 		if e != nil {
-			return "", fmt.Errorf("There was an error Unmarshalling response: %v", e)
+			return nil, fmt.Errorf("There was an error Unmarshalling response: %v", e)
 		}
 		log.Printf("Silence Created with ID %s.", silenceResp.ID)
-		return silenceResp.ID, nil
+		return &silenceResp, nil
 	}
 }
 
 // Remove deletes the silence with the given silenceID
-func Remove(silenceID string) error {
-	log.Printf("Removing Silence %s\n", silenceID)
+func (sr *SilenceRequest) Remove() error {
+	log.Printf("Removing Silence %s\n", sr.ID)
 	for i := 0; i < 5; i++ {
 		// Attempt up to 5 times to unsilence the cluster
-		unsilenceCommand := exec.Command("oc", "exec", "-n", "openshift-monitoring", "alertmanager-main-0", "-c", "alertmanager", "--", "curl", fmt.Sprintf("localhost:9093/api/v2/silence/%s", silenceID), "--silent", "-X", "DELETE")
+		unsilenceCommand := exec.Command("oc", "exec", "-n", "openshift-monitoring", "alertmanager-main-0", "-c", "alertmanager", "--", "curl", fmt.Sprintf("localhost:9093/api/v2/silence/%s", sr.ID), "--silent", "-X", "DELETE")
 		unsilenceCommand.Stderr = os.Stderr
 		err := unsilenceCommand.Run()
 		if err != nil {
@@ -145,24 +158,21 @@ func Remove(silenceID string) error {
 	return fmt.Errorf("there was an error unsilencing the cluster")
 }
 
-func Update(amSilence *silence.SilenceRequest) error {
-	now := time.Now().UTC()
-	end := now.Add(5 * time.Minute)
-
-	// Modify existing silence StartsAt and EndsAt files with + timePeriod from now
-
-	// POST update silence to Alertmanager
-}
-
 // ExpiresIn returns bool if the remaining time on the AlertManager Silence is less than the expiryPeriod
-func ExpiresIn(amSilence *silence.SilenceRequest, expiryPeriod time.Duration) (bool, error) {
+func (sr *SilenceRequest) WillExpireBy(expiryPeriod time.Duration) (bool, error) {
 	// Parse start and end times of Alertmanager Silence
-	start := time.Parse(time.RFC3339, amSilence.StartsAt)
-	end := time.Parse(time.RFC3339, amSilence.EndsAt)
+	start, err := time.Parse(time.RFC3339, sr.StartsAt)
+	if err != nil {
+		return false, err
+	}
+	end, err := time.Parse(time.RFC3339, sr.EndsAt)
+	if err != nil {
+		return false, err
+	}
 
 	// Find the remaining time left on the silence
 	remaining := end.Sub(start)
 
 	// Return bool if the remaining time is less than the expiryPeriod
-	return remaining < expiryPeriod
+	return remaining < expiryPeriod, nil
 }

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -11,6 +11,7 @@ import (
 
 const createdBy = "OSD Cluster Readiness Job"
 
+// SilenceRequest represents a Alertmanager silence request object
 type SilenceRequest struct {
 	ID        string       `json:"id"`
 	Status    silenceState `json:"status"`
@@ -100,10 +101,7 @@ func (sr *SilenceRequest) Build(expiryPeriod time.Duration) *SilenceRequest {
 
 	allMatcher := matcher{}
 	allMatcher.Name = "severity"
-	// Match all alerts
-	// This doesn't work and should, maybe it needs better escaping?
-	// allMatcher.Value = ".*"
-	allMatcher.Value = "(Critical|Warning)"
+	allMatcher.Value = "info|warning|critical"
 	allMatcher.IsRegex = true
 
 	sr.Matchers = []matcher{allMatcher}
@@ -144,7 +142,7 @@ func (sr *SilenceRequest) Send() (*silenceResponse, error) {
 	}
 }
 
-// Remove deletes the silence with the given silenceID
+// Remove deletes the silence with the given sr.ID
 func (sr *SilenceRequest) Remove() error {
 	log.Printf("Removing Silence %s\n", sr.ID)
 	for i := 0; i < 5; i++ {
@@ -163,7 +161,7 @@ func (sr *SilenceRequest) Remove() error {
 	return fmt.Errorf("there was an error unsilencing the cluster")
 }
 
-// ExpiresIn returns bool if the remaining time on the AlertManager Silence is less than the expiryPeriod
+// WillExpireBy returns bool if the remaining time on the AlertManager Silence is less than the expiryPeriod
 func (sr *SilenceRequest) WillExpireBy(expiryPeriod time.Duration) (bool, error) {
 	// Parse end time of Alertmanager Silence
 	end, err := time.Parse(time.RFC3339, sr.EndsAt)

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -144,3 +144,25 @@ func Remove(silenceID string) error {
 	}
 	return fmt.Errorf("there was an error unsilencing the cluster")
 }
+
+func Update(amSilence *silence.SilenceRequest) error {
+	now := time.Now().UTC()
+	end := now.Add(5 * time.Minute)
+
+	// Modify existing silence StartsAt and EndsAt files with + timePeriod from now
+
+	// POST update silence to Alertmanager
+}
+
+// ExpiresIn returns bool if the remaining time on the AlertManager Silence is less than the expiryPeriod
+func ExpiresIn(amSilence *silence.SilenceRequest, expiryPeriod time.Duration) (bool, error) {
+	// Parse start and end times of Alertmanager Silence
+	start := time.Parse(time.RFC3339, amSilence.StartsAt)
+	end := time.Parse(time.RFC3339, amSilence.EndsAt)
+
+	// Find the remaining time left on the silence
+	remaining := end.Sub(start)
+
+	// Return bool if the remaining time is less than the expiryPeriod
+	return remaining < expiryPeriod
+}


### PR DESCRIPTION
To ensure that a silence is always active we set the silence at the beginning of the for loop before we run the healthcheck. 

If there is no silence set, we set it to 1 hour and remove the silence if the healthcheck is successful. If the healthcheck is not successful we loop and validate that silence is at least active for another 15 minutes before running the next healthcheck, if it isn't we edit the healthcheck and set it to expire in 15 minutes from `now`. 

Future updates:
Don't set the updated silence to 15 minutes, we could compute the total time required from available envs.