### PR TITLE
Update deploy scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,33 @@
-IMAGE_REPO ?= quay.io
-IMAGE_ORG ?= openshift-sre
-IMAGE_NAME ?= osd-cluster-ready
 IMAGE_URI ?= $(IMAGE_REPO)/$(IMAGE_ORG)/$(IMAGE_NAME)
+
+# Project specific values
+DOCKER_IMAGE_REGISTRY?=docker.io
+QUAY_IMAGE_REGISTRY?=quay.io
+IMAGE_REPOSITORY?=openshift-sre
+IMAGE_NAME?=osd-cluster-ready
+DOCKERFILE=./Dockerfile
+
+# Podman by default, fall back to docker
+CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+
+# Gather commit number for Z and short SHA
+COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
+CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
+
+# Build container version
+VERSION_MAJOR?=0
+VERSION_MINOR?=1
+CONTAINER_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
+
+# Quay.io image
+QUAY_IMG?=$(QUAY_IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):v$(CONTAINER_VERSION)
+QUAY_IMAGE_URI=${QUAY_IMG}
+QUAY_IMAGE_URI_LATEST=$(QUAY_IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):latest
+
+# Docker image
+DOCKER_IMG?=$(DOCKER_IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):v$(CONTAINER_VERSION)
+DOCKER_IMAGE_URI=${DOCKER_IMG}
+DOCKER_IMAGE_URI_LATEST=$(DOCKER_IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):latest
 
 .PHONY: build
 build:
@@ -9,8 +35,22 @@ build:
 
 .PHONY: docker-build
 docker-build: build
-	docker build . -t $(IMAGE_URI)
+	# Build and tag images for quay.io
+	${CONTAINER_ENGINE} build . -f $(DOCKERFILE) -t $(QUAY_IMAGE_URI)
+	${CONTAINER_ENGINE} tag $(QUAY_IMAGE_URI) $(QUAY_IMAGE_URI_LATEST)
+	# Tag docker images
+	${CONTAINER_ENGINE} tag $(QUAY_IMAGE_URI) $(DOCKER_IMAGE_URI)
+	${CONTAINER_ENGINE} tag $(DOCKER_IMAGE_URI) $(DOCKER_IMAGE_URI_LATEST)
 
 .PHONY: docker-push
 docker-push:
-	docker push $(IMAGE_URI)
+	# Push Quay.io images
+	${CONTAINER_ENGINE} push $(QUAY_IMAGE_URI)
+	${CONTAINER_ENGINE} push $(QUAY_IMAGE_URI_LATEST)
+	# Push Docker images
+	# ${CONTAINER_ENGINE} push $(DOCKER_IMAGE_URI)
+	# ${CONTAINER_ENGINE} push $(DOCKER_IMAGE_URI_LATEST)
+
+.PHONY: deploy
+deploy:
+	hack/deploy.sh

--- a/deploy/60-osd-ready.Job.yaml
+++ b/deploy/60-osd-ready.Job.yaml
@@ -17,6 +17,7 @@ spec:
                 value: "240"
               name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready
+              imagePullPolicy: Always
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [ -z "$IMAGE_REPOSITORY" ]; then
+  echo "Not set"
+else
+  echo "$IMAGE_REPOSITORY"
+fi
+# Gather commit number for Z and short SHA
+COMMIT_NUMBER=$(git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$"`..HEAD --count)
+CURRENT_COMMIT=$(git rev-parse --short=7 HEAD)
+
+# Build container version
+VERSION_MAJOR=0
+VERSION_MINOR=1
+CONTAINER_VERSION="v$VERSION_MAJOR.$VERSION_MINOR.$COMMIT_NUMBER-$CURRENT_COMMIT"
+
+TMP_MANIFEST=$(mktemp)
+echo "Created $TMP_MANIFEST"
+cat deploy/60-osd-ready.Job.yaml | sed "s/openshift-sre/${IMAGE_REPOSITORY}/" > $TMP_MANIFEST
+sed -i "s/\/osd-cluster-ready/\/osd-cluster-ready:${CONTAINER_VERSION}/" $TMP_MANIFEST
+sed -i "s/value: \"240\"/value: \"339860\"/" $TMP_MANIFEST
+trap "rm -fr $TMP_MANIFEST" EXIT
+cat $TMP_MANIFEST
+
+oc delete job -n openshift-monitoring osd-cluster-ready
+
+for manifest in $(ls deploy/ | grep -v "60-osd-ready.Job.yaml")
+do
+    oc apply -f deploy/${manifest}
+done
+
+oc apply -f $TMP_MANIFEST
+
+# oc logs -f jobs/osd-cluster-ready -n openshift-monitoring


### PR DESCRIPTION
Update deploy scripts:

1. Create semver for pods so that we don't rely on latest
1.b Update job spec imagePullPolicy to `always` caching of the latest image caught me out
2. Default to podman, fail back to docker for builds
3. Build image and tag for both Quay and Docker (could be removed since we don't have a docker repo right now)
4. Add very simple deploy script `hack/deploy.sh` triggered by `make deploy` that can be prefixed with `IMAGE_REPOSITORY=jharrington22` for example to push to personal image repository
5. `deploy.sh` currently `sed`'s image name and `MAX_CLUSTER_AGE_MINUTES` values in `deploy/60-osd-ready.Job.yml`

The above changes allow the osd-cluster-ready job to be deployed to a current cluster (using current context) with `IMAGE_REPOSITORY=jharrington22 make deploy`

Future notes:
`deploy.sh` could be parameterized and could be updated to use yq or something similar for better in place editing.