### PR TITLE
Calculate maxHealthCheckDuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,13 @@
 
 This job silences alerts while Day2 configuration is loaded onto a cluster at initial provisioning, allowing it to not page on-call SREs for normal operations within the cluster.
 
-The silence initially takes effect for 1 hour.
-
 We poll cluster health using [osde2e health checks](https://github.com/openshift/osde2e/blob/041355675304a7aa371b7fbeea313001036feb75/pkg/common/cluster/clusterutil.go#L211)
 once a minute (this is [configurable](#failed_check_interval_seconds)),
 until they all report healthy 20 times in a row ([configurable](#clean_check_runs))
 on 30s intervals ([configurable](#clean_check_interval_seconds)).
 By default, we will clear any active silence and exit successfully if the cluster is (or becomes) more than two hours old ([configurable](#max_cluster_age_minutes)).
 
-If we think the silence might expire while health checks are running, we extend it.
+We base the duration of the silence on the estimated maximum time we think it should take for the full health check sequence to run, extending it as necessary.
 
 ## Deploying
 
@@ -122,5 +120,5 @@ Don't forget to [build](#deploying-the-image) and [test](#deploying-the-job) wit
 - [x] Look for existing active silences before creating a new one
 - [x] Implement _actual_ healthchecks (steal them from osde2e) to determine cluster stability
 - [x] Make the default silence expiry shorter; and extend it when health checks fail ([OSD-6384](https://issues.redhat.com/browse/OSD-6384)).
-- [ ] Find if there's a better and more secure way to talk to the alertmanager API using oauth and serviceaccount tokens.
+- [ ] Find out if there's a better and more secure way to talk to the alertmanager API using oauth and serviceaccount tokens.
 - [ ] Make [tunables](#tunables) configurable via `make deploy`.

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -48,7 +48,11 @@ fi
 
 # Before deploying the new job, make sure the pod from the old one is gone
 if [[ $WAIT_FOR_POD == "yes" ]]; then
-  maybe oc wait --for=delete pod -l job-name=osd-cluster-ready --timeout=30s
+  # FIXME: This can fail for two reasons:
+  # - Timeout, in which case we want to blow up.
+  # - The pod already disappeared, in which case we want to proceed.
+  # Scraping the output is icky. For now, just ignore errors.
+  maybe oc wait --for=delete pod -l job-name=osd-cluster-ready --timeout=30s || true
 fi
 
 maybe oc create -f $TMP_MANIFEST

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -78,7 +78,7 @@ func (sr *Request) FindExisting() (*Request, error) {
 			}
 
 			if !silence.Active() {
-				log.Printf("Silence is not active.")
+				log.Printf("Silence %s is not active.", silence.ID)
 				continue
 			}
 
@@ -162,7 +162,9 @@ func (sr *Request) Remove() error {
 	return fmt.Errorf("there was an error unsilencing the cluster")
 }
 
-// WillExpireBy returns bool if the remaining time on the AlertManager Silence is less than the expiryPeriod
+// WillExpireBy returns:
+// - bool: true if the remaining time on the AlertManager Silence is less than the expiryPeriod.
+// - error: nil unless the silence request's end time can't be parsed.
 func (sr *Request) WillExpireBy(expiryPeriod time.Duration) (bool, error) {
 	// Parse end time of Alertmanager Silence
 	end, err := time.Parse(time.RFC3339, sr.EndsAt)


### PR DESCRIPTION
Calculate the maximum expected time it should take to run the full health check loop, and use both to initialize the silence and to extend it on any failure.

Log sample:
```
2021/02/19 22:29:17 Cluster Created 2021-02-18 15:53:05 +0000 UTC
2021/02/19 22:29:17 Using a silence expiry window of 16m20s.
2021/02/19 22:29:17 Checking for silences
2021/02/19 22:29:31 Found silence created by job: f5b2e3f4-ae4f-4548-99b3-9ad2a8067bb2
2021/02/19 22:29:31 Time remaining on active silence: 14m12.238929097s
2021/02/19 22:29:31 Silence expires in less than 16m20s. Extending.
2021/02/19 22:29:45 Silence Created with ID ab639162-820a-4ac4-8946-85a5dc511d30.
<le big snip>
2021/02/19 22:42:48 Health checks succeeded.
2021/02/19 22:42:48 Time remaining on active silence: 6m31.917376129s
2021/02/19 22:42:48 Removing Silence ab639162-820a-4ac4-8946-85a5dc511d30
2021/02/19 22:43:01 Silence Successfully Removed.
```