### PR TITLE
OSD-6272 Fix CI build by not using .. in paths

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,9 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
 
 WORKDIR /go/src/osd-cluster-ready
-COPY ../go.mod ../go.sum ./
+COPY go.mod go.sum ./
 RUN go mod download
-COPY .. .
+COPY . .
 RUN make build
 
 FROM registry.access.redhat.com/ubi8/ubi-micro:latest


### PR DESCRIPTION
The CI is failing to build this due to:
```
09:24:36 Step 3/8 : COPY ../go.mod ../go.sum ./
09:24:36 COPY failed: forbidden path outside the build context: ../go.mod ()
```
Interestingly both do the same thing locally, but I've learned that what I had earlier is an anti-pattern anyway