### PR TITLE
Fix make test when it runs in the CI container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ include boilerplate/generated-includes.mk
 
 .PHONY: build
 build:
-	GOOS=linux go build -mod=mod -ldflags="-s -w" -o ./bin/main main.go
+	GOOS=linux go build -mod=readonly -ldflags="-s -w" -o ./bin/main main.go
 
 .PHONY: test
 test:
-	go test -v ./...
+	go test -mod=readonly -v ./...
 
 .PHONY: deploy
 deploy:


### PR DESCRIPTION
The last run in prow is failing: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/28244/rehearse-28244-pull-ci-openshift-osd-cluster-ready-master-test/1520130828724604928 due to the base image having `-mod=vendor` set...