### PR TITLE
Adds linting to makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 10
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  # We're using a somewhat resource-constrained container in the CI
+  # environment, so make this longish.
+  timeout: 10m
+
+issues:
+  # We want to make sure we get a full report every time. Setting these
+  # to zero disables the limit.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+  - deadcode
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - structcheck
+  - typecheck
+  - unused
+  - varcheck
+  - gosec
+

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ test:
 .PHONY: deploy
 deploy:
 	hack/deploy.sh
+
+.PHONY: lint
+lint:
+	golangci-lint run


### PR DESCRIPTION
Introduces a .golangci lint configuration file and a lint target in the
Makefile.

Attempts to satisfy [OSD-11462](https://issues.redhat.com//browse/OSD-11462)
