### PR TITLE
fixes issues with linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,9 @@ run:
   # We're using a somewhat resource-constrained container in the CI
   # environment, so make this longish.
   timeout: 10m
+  # set this to readonly so it doesn't complain about the lack of a
+  # vendor directory
+  modules-download-mode: readonly
 
 issues:
   # We want to make sure we get a full report every time. Setting these

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Project specific values
 IMAGE_NAME ?= osd-cluster-ready
 
+# GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
+# Relevant issue - https://github.com/golangci/golangci-lint/issues/734
+GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
+
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
@@ -21,4 +25,4 @@ deploy:
 
 .PHONY: lint
 lint:
-	golangci-lint run
+	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run --mod=readonly ./...


### PR DESCRIPTION
Fixes the issue with linting by using the temp dir instead of `/.cache`. This also updates the config so the linter runs successfully.
