### PR TITLE
empty commit to trigger build of images for remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Once the cluster is truly healthy, you can expect the job to succeed after an in
 ## TO DO
 
 - [x] Implement _actual_ healthchecks (steal them from osde2e) to determine cluster stability
+


### PR DESCRIPTION
Addresses [OSD-13325](https://issues.redhat.com/browse/OSD-13325), remediates CVE's found in the base image by rebuilding off the latest ubi-micro.