### PR TITLE
Adds dependabot configuration for osd-cluster-ready

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/build"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "app-sre/boilerplate"
+        # don't upgrade boilerplate via these means
+  - package-ecosystem: gomod
+    directory: "/"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+    schedule:
+      interval: "weekly"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,6 +6,6 @@ RUN go mod download
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.6-526
 
 COPY --from=builder /go/src/osd-cluster-ready/bin/main /root/


### PR DESCRIPTION
This creates a dependabot configuration for osd-cluster-ready.

This will check for go module updates (basically updates to osde2e), as well as updates to the ubi-micro base image which will remediate any security issues.