### PR TITLE
OSD-29557: Drop defunct optional golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,0 @@
-linters:
-  disable-all: true
-  enable:
-  - gosec

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 # Project specific values
 IMAGE_NAME ?= osd-cluster-ready
-# Extra Lint Config
-GOLANGCI_OPTIONAL_CONFIG = ./.golangci.yml
 
 .PHONY: boilerplate-update
 boilerplate-update:


### PR DESCRIPTION
In https://github.com/openshift/boilerplate/pull/523 we dropped support for GOLANGCI_OPTIONAL_CONFIG.

This is one of two repos which was configuring it, however it has been previously removed in https://github.com/openshift/osd-metrics-exporter/commit/8d83dc8851329746949f3d31a2ed87458bbbf042 but the config option was left.

This just cleans that up.