### PR TITLE
SDCICD-1555: copy LICENSE and set USER

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,5 +7,11 @@ COPY . .
 RUN make build
 
 FROM registry.access.redhat.com/ubi8/ubi-micro:8.10-24
+WORKDIR /
 
-COPY --from=builder /go/src/osd-cluster-ready/bin/main /root/
+RUN mkdir /licenses
+COPY --from=builder /go/src/osd-cluster-ready/LICENSE /licenses/.
+COPY --from=builder /go/src/osd-cluster-ready/bin/main /osd-cluster-ready
+
+USER 65532:65532
+ENTRYPOINT ["/osd-cluster-ready"]

--- a/deploy/60-osd-ready.Job.yaml
+++ b/deploy/60-osd-ready.Job.yaml
@@ -12,6 +12,5 @@ spec:
             - name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready
               imagePullPolicy: Always
-              command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready


### PR DESCRIPTION
Konflux checks that the image contains a license directory with all
relevant licenses, and that the image is running as non-root. It will
fail to release the image otherwise -

```json
{
    "name": "HasLicense",
    "elapsed_time": 0,
    "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
    "help": "Check HasLicense encountered an error. Please review the preflight.log file for more information.",
    "suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
    "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
    "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
},
{
    "name": "RunAsNonRoot",
    "elapsed_time": 0,
    "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
    "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
    "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
    "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
    "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
}
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>
