### PR TITLE
reduce the check run count to 10

### DIFF
--- a/deploy/60-osd-ready.Job.yaml
+++ b/deploy/60-osd-ready.Job.yaml
@@ -12,5 +12,8 @@ spec:
             - name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready
               imagePullPolicy: Always
+              env:
+              - name: CLEAN_CHECK_RUNS
+                value: "10"
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready


### PR DESCRIPTION
It will take a lot of time to check 20 times, especially when in CI testing.

The cluster creation is quite stable now, I do not think we need to wait such long time.