### PR TITLE
ROSA-745: enable MintMaker gomod managers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>openshift/boilerplate//.github/renovate.json"
+  ],
+  "enabledManagers": [
+    "tekton",
+    "gomod"
   ]
 }


### PR DESCRIPTION
## Summary

Minimal [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) MintMaker enablement:

- `.github/renovate.json` — `enabledManagers: [tekton, gomod]` so MintMaker opens gomod PRs
- `make boilerplate-update` only when master is behind openshift/boilerplate and no equivalent update is already open

No unrelated generated churn beyond PKO fixture regeneration where validate requires it.

## Test plan

- [ ] Required prow + Konflux `*-on-pull-request` checks green
- [ ] MintMaker Dependency Dashboard shows gomod after merge

Jira: [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded dependency update automation to cover additional package ecosystems, helping keep project dependencies current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->